### PR TITLE
fix menu being hidden behind main widget

### DIFF
--- a/game.cpp
+++ b/game.cpp
@@ -18,6 +18,7 @@ GameWindow::GameWindow(QWidget *parent)
 
     // создать сцену
     view = new GameView(this);
+	view->move(view->pos().x(), view->pos().y() + menuBar->height());
 }
 
 GameView::GameView(QWidget *parent)


### PR DESCRIPTION
Just move main widget below its own position by height of menubar
